### PR TITLE
Fix bug in title tag when subtitle missing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
 
         {% block title -%}
-        <title>{{ config.title }} | {{ config.extra.subtitle }}</title>
+            {% if config.extra.subtitle %}
+                <title>{{ config.title }} | {{ config.extra.subtitle }}</title>
+            {% else %}
+                <title>{{ config.title }}</title>
+            {% endif %}
         <meta property="og:title" content="{{ config.title }}" />
         <meta name="twitter:title" content="{{ config.title }}" />
         {%- endblock title %}


### PR DESCRIPTION
If `subtitle` is not set in extra then an error will occur when rendering the index template (specifically in the <title> tag). This change checks for the presence of a subtitle before attempting to render it.

Additionally, if the subtitle was the empty string the title would be rendered with an additional | character after the name (e.g. `mysite |`). This change removes that character when the subtitle is not present.

P.S. Thanks for putting together this theme @lukehsiao! I am using it at https://blog.rosenext.com. Your efforts are appreciated. 