### PR TITLE
Mark katex shortcode body as safe

### DIFF
--- a/templates/shortcodes/katex.html
+++ b/templates/shortcodes/katex.html
@@ -1,1 +1,1 @@
-<script type="math/tex{% if block %};mode=display{% endif %}">{{body}}</script>
+<script type="math/tex{% if block %};mode=display{% endif %}">{{body | safe}}</script>


### PR DESCRIPTION
Stop zola from escaping characters meant for katex such as `<` and `>`.

Closes #4 