### PR TITLE
Strip tags from page summary before trunc

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,7 +80,7 @@
                     {% if page.summary -%}
                     {{ post_macros::polish(content=page.summary) }}
                     {% else %}
-                    {{ post_macros::polish(content=page.content) | truncate(length=280) }}
+                    {{ post_macros::polish(content=page.content) | striptags | truncate(length=280) }}
                     {%- endif %}
                 </div>
                 <a href="{{ page.permalink }}" class="c-article__btn p-list-article__btn">Read more...</a>


### PR DESCRIPTION
Strip tags from the page summary before truncating the content to be
disapled on the front page. If the content truncates at the middle of an
open tag, i.e. does not include a closing tag in the 280 chars, the Read
more anchor tag is corrupted.

Documented in https://github.com/getzola/zola/issues/1149